### PR TITLE
Changed the internal Error enum to use CowString<'static>

### DIFF
--- a/src/char.rs
+++ b/src/char.rs
@@ -1,5 +1,6 @@
 use primitives::{Consumed, Parser, ParseError, ParseResult, Error, State, Stream};
 use combinator::{FnParser, many, Many, Map, ParserExt, With};
+use std::borrow::IntoCow;
 
 macro_rules! impl_char_parser {
     ($name: ident ($($ty_var: ident),*), $inner_type: ty) => {
@@ -71,7 +72,7 @@ pub fn digit<I>() -> Digit<I>
             Ok((c, rest)) => {
                 if c.is_digit(10) { Ok((c, rest)) }
                 else {
-                    Err(Consumed::Empty(ParseError::new(input.position, Error::Message("Expected digit".to_string()))))
+                    Err(Consumed::Empty(ParseError::new(input.position, Error::Message("Expected digit".into_cow()))))
                 }
             }
             Err(err) => Err(err)
@@ -172,7 +173,7 @@ impl <'a, I> Parser for StringP<'a, I>
             match input.combine(|input| input.uncons_char()) {
                 Ok((other, rest)) => {
                     if c != other {
-                        let error = ParseError::new(start, Error::Expected(self.s.to_string()));
+                        let error = ParseError::new(start, Error::Expected(self.s.to_string().into_cow()));
                         return Err(if i == 0 { Consumed::Empty(error) } else { Consumed::Consumed(error) });
                     }
                     input = rest;

--- a/src/combinator.rs
+++ b/src/combinator.rs
@@ -1,5 +1,6 @@
-
 use std::iter::FromIterator;
+use std::string::CowString;
+use std::borrow::IntoCow;
 use primitives::{Parser, ParseResult, ParseError, Stream, State, Error, Consumed};
 
 macro_rules! impl_parser {
@@ -91,7 +92,7 @@ pub fn many<F, P>(p: P) -> Many<F, P>
 }
 
 #[derive(Clone)]
-pub struct Unexpected<I>(String);
+pub struct Unexpected<I>(CowString<'static>);
 impl <I> Parser for Unexpected<I>
     where I : Stream {
     type Input = I;
@@ -107,16 +108,18 @@ impl <I> Parser for Unexpected<I>
 /// # extern crate "parser-combinators" as pc;
 /// # use pc::*;
 /// # use pc::primitives::Error;
+/// # use std::borrow::IntoCow;
 /// # fn main() {
-/// let result = unexpected("token".to_string())
+/// let result = unexpected("token")
 ///     .parse("a");
 /// assert!(result.is_err());
-/// assert_eq!(result.err().unwrap().errors[0], Error::Message("token".to_string()));
+/// assert_eq!(result.err().unwrap().errors[0], Error::Message("token".into_cow()));
 /// # }
 /// ```
-pub fn unexpected<I>(message: String) -> Unexpected<I>
-    where I: Stream {
-    Unexpected(message)
+pub fn unexpected<I, S>(message: S) -> Unexpected<I>
+    where I: Stream
+        , S: IntoCow<'static, String, str> {
+    Unexpected(message.into_cow())
 }
 
 #[derive(Clone)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -131,6 +131,7 @@ pub mod char;
 mod tests {
     use super::*;
     use super::primitives::{SourcePosition, State, Stream, Error, Consumed};
+    use std::borrow::IntoCow;
     
 
     fn integer<'a, I>(input: State<I>) -> ParseResult<i64, I>
@@ -235,7 +236,7 @@ r"
             .parse(input);
         let err = ParseError {
             position: SourcePosition { line: 2, column: 1 },
-            errors: vec![Error::Unexpected(','), Error::Message("Expected digit".to_string())]
+                errors: vec![Error::Unexpected(','), Error::Message("Expected digit".into_cow())]
         };
         assert_eq!(result, Err(err));
     }


### PR DESCRIPTION
Most of the error messages are &'static str which means using a String as the message type is usually a waste allocation.

The parser API should still be relatively unaware of this change since the only change was String -> T where T: IntoCow