### PR TITLE
Added custom positioning

### DIFF
--- a/benches/json.rs
+++ b/benches/json.rs
@@ -104,7 +104,7 @@ impl <I> Json<I>
     }
     fn object(input: State<I>) -> ParseResult<Value, I> {
         let field = (lex(parser(Json::<I>::string)), lex(char(':')), lex(parser(Json::<I>::value)))
-            .map(|t| (t.0, t.1);
+            .map(|t| (t.0, t.2));
         let fields = sep_by(field, char(','));
         between(char('{'), lex(char('}')), fields)
             .map(Value::Object)

--- a/benches/json.rs
+++ b/benches/json.rs
@@ -7,9 +7,9 @@ use std::io::Read;
 use std::fs::File;
 use std::path::Path;
 
-use pc::primitives::{Parser, State, Stream, ParseResult};
-use pc::combinator::{between, many, many1, optional, parser, sep_by, unexpected, With, ParserExt};
-use pc::char::{any_char, char, digit, satisfy, spaces, Spaces, string};
+use pc::primitives::{Parser, State, Stream};
+use pc::combinator::{any, between, many, many1, optional, parser, satisfy, sep_by, unexpected, With, ParserExt};
+use pc::char::{char, digit, spaces, Spaces, string, ParseResult};
 
 #[derive(PartialEq, Debug)]
 enum Value {
@@ -78,7 +78,7 @@ impl <I> Json<I>
     }
 
     fn char(input: State<I>) -> ParseResult<char, I> {
-        let (c, input) = try!(any_char().parse_state(input));
+        let (c, input) = try!(any().parse_state(input));
         let mut back_slash_char = satisfy(|c| "\"\\/bfnrt".chars().find(|x| *x == c).is_some()).map(|c| {
             match c {
                 '"' => '"',

--- a/src/char.rs
+++ b/src/char.rs
@@ -21,35 +21,6 @@ macro_rules! impl_char_parser {
 }
 
 #[derive(Clone)]
-pub struct AnyChar<I>(PhantomData<fn (I) -> I>);
-
-impl <I> Parser for AnyChar<I>
-    where I: Stream<Item=char> {
-    type Input = I;
-    type Output = char;
-    fn parse_state(&mut self, input: State<I>) -> ParseResult<char, I> {
-        input.uncons_char()
-    }
-}
-
-///Parses any character
-///
-/// ```
-/// # extern crate parser_combinators as pc;
-/// # use pc::*;
-/// # fn main() {
-/// let mut parser = any_char();
-/// assert_eq!(parser.parse("!").map(|x| x.0), Ok('!'));
-/// assert!(parser.parse("").is_err());
-/// # }
-/// ```
-pub fn any_char<I>() -> AnyChar<I>
-    where I: Stream<Item=char> {
-    AnyChar(PhantomData)
-}
-
-
-#[derive(Clone)]
 pub struct Satisfy<I, Pred> { pred: Pred, _marker: PhantomData<I> }
 
 impl <I, Pred> Parser for Satisfy<I, Pred>

--- a/src/char.rs
+++ b/src/char.rs
@@ -145,7 +145,7 @@ impl <I> Parser for String<I>
         let start = input.position;
         let mut consumed = false;
         for c in self.0.chars() {
-            match input.uncons_char() {
+            match input.uncons() {
                 Ok((other, rest)) => {
                     if c != other {
                         let errors = vec![Error::Unexpected(other), Error::Expected(self.0.into())];

--- a/src/char.rs
+++ b/src/char.rs
@@ -1,5 +1,5 @@
 use primitives::{Consumed, Parser, ParseError, Error, State, Stream};
-use combinator::{Expected, skip_many, SkipMany, ParserExt, With};
+use combinator::{Expected, satisfy, Satisfy, skip_many, SkipMany, token, Token, ParserExt, With};
 use std::marker::PhantomData;
 
 pub type ParseResult<O, I> = ::primitives::ParseResult<O, I, char>;
@@ -20,65 +20,6 @@ macro_rules! impl_char_parser {
 }
 }
 
-#[derive(Clone)]
-pub struct Satisfy<I, Pred> { pred: Pred, _marker: PhantomData<I> }
-
-impl <I, Pred> Parser for Satisfy<I, Pred>
-    where I: Stream<Item=char>, Pred: FnMut(char) -> bool {
-
-    type Input = I;
-    type Output = char;
-    fn parse_state(&mut self, input: State<I>) -> ParseResult<char, I> {
-        match input.clone().uncons_char() {
-            Ok((c, s)) => {
-                if (self.pred)(c) { Ok((c, s)) }
-                else {
-                    Err(Consumed::Empty(ParseError::new(input.position, Error::Unexpected(c))))
-                }
-            }
-            Err(err) => Err(err)
-        }
-    }
-}
-
-///Parses a character and succeeds depending on the result of `pred`
-///
-/// ```
-/// # extern crate parser_combinators as pc;
-/// # use pc::*;
-/// # fn main() {
-/// let mut parser = satisfy(|c| c == '!' || c == '?');
-/// assert_eq!(parser.parse("!").map(|x| x.0), Ok('!'));
-/// assert_eq!(parser.parse("?").map(|x| x.0), Ok('?'));
-/// # }
-/// ```
-pub fn satisfy<I, Pred>(pred: Pred) -> Satisfy<I, Pred>
-    where I: Stream<Item=char>, Pred: FnMut(char) -> bool {
-    Satisfy { pred: pred, _marker: PhantomData }
-}
-
-#[derive(Clone)]
-pub struct Char<I> { c: char, _marker: PhantomData<I> }
-
-impl <I> Parser for Char<I>
-    where I: Stream<Item=char> {
-
-    type Input = I;
-    type Output = char;
-    fn parse_state(&mut self, input: State<I>) -> ParseResult<char, I> {
-        match input.clone().uncons_char() {
-            Ok((c, s)) => {
-                if self.c == c { Ok((c, s)) }
-                else {
-                    let errors = vec![Error::Unexpected(c), Error::Expected(self.c.into())];
-                    Err(Consumed::Empty(ParseError::from_errors(input.position, errors)))
-                }
-            }
-            Err(err) => Err(err)
-        }
-    }
-}
-
 ///Parses a character and succeeds if the characther is equal to `c`
 ///
 /// ```
@@ -91,9 +32,9 @@ impl <I> Parser for Char<I>
 /// assert_eq!(result, Ok('!'));
 /// # }
 /// ```
-pub fn char<I>(c: char) -> Char<I>
+pub fn char<I>(c: char) -> Token<I>
     where I: Stream<Item=char> {
-    Char { c: c, _marker: PhantomData }
+    token(c)
 }
 
 impl_char_parser! { Digit(), Expected<Satisfy<I, fn (char) -> bool>> }

--- a/src/char.rs
+++ b/src/char.rs
@@ -1,6 +1,8 @@
-use primitives::{Consumed, Parser, ParseError, ParseResult, Error, State, Stream};
+use primitives::{Consumed, Parser, ParseError, Error, State, Stream};
 use combinator::{Expected, skip_many, SkipMany, ParserExt, With};
 use std::marker::PhantomData;
+
+pub type ParseResult<O, I> = ::primitives::ParseResult<O, I, char>;
 
 macro_rules! impl_char_parser {
     ($name: ident ($($ty_var: ident),*), $inner_type: ty) => {

--- a/src/combinator.rs
+++ b/src/combinator.rs
@@ -18,6 +18,37 @@ macro_rules! impl_parser {
 }
 }
 
+#[derive(Clone)]
+pub struct Any<I>(PhantomData<fn (I) -> I>);
+
+impl <I> Parser for Any<I>
+    where I: Stream {
+    type Input = I;
+    type Output = I::Item;
+    fn parse_state(&mut self, input: State<I>) -> ParseResult<I::Item, I, I::Item> {
+        input.uncons()
+    }
+}
+
+///Parses any token
+///
+/// ```
+/// # extern crate parser_combinators as pc;
+/// # use pc::*;
+/// # fn main() {
+/// let mut char_parser = any();
+/// assert_eq!(char_parser.parse("!").map(|x| x.0), Ok('!'));
+/// assert!(char_parser.parse("").is_err());
+/// let mut byte_parser = any();
+/// assert_eq!(byte_parser.parse(&b"!"[..]).map(|x| x.0), Ok(&b'!'));
+/// assert!(byte_parser.parse(&b""[..]).is_err());
+/// # }
+/// ```
+pub fn any<I>() -> Any<I>
+    where I: Stream {
+    Any(PhantomData)
+}
+
 pub struct Choice<S, P>(S, PhantomData<P>);
 
 impl <I, O, S, P> Parser for Choice<S, P>

--- a/src/combinator.rs
+++ b/src/combinator.rs
@@ -90,13 +90,15 @@ pub fn satisfy<I, P>(predicate: P) -> Satisfy<I, P>
 
 #[derive(Clone)]
 pub struct Token<I>
-    where I: Stream {
+    where I: Stream
+        , I::Item: PartialEq {
     c: I::Item,
     _marker: PhantomData<I>
 }
 
 impl <I> Parser for Token<I>
-    where I: Stream {
+    where I: Stream
+        , I::Item: PartialEq {
 
     type Input = I;
     type Output = I::Item;
@@ -127,7 +129,8 @@ impl <I> Parser for Token<I>
 /// # }
 /// ```
 pub fn token<I>(c: I::Item) -> Token<I>
-    where I: Stream {
+    where I: Stream
+        , I::Item: PartialEq {
     Token { c: c, _marker: PhantomData }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -116,7 +116,6 @@ pub use char::{
     hex_digit,
     oct_digit,
     string,
-    satisfy,
 
     ParseResult//use char::ParseResult for compatibility
 };
@@ -130,9 +129,11 @@ pub use combinator::{
     many1,
     optional,
     parser,
+    satisfy,
     sep_by,
     skip_many,
     skip_many1,
+    token,
     try,
     value,
     unexpected,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -324,7 +324,7 @@ r"
 
 
     fn follow(input: State<&str>) -> ParseResult<(), &str> {
-        match input.clone().uncons_char() {
+        match input.clone().uncons() {
             Ok((c, _)) => {
                 if c.is_alphanumeric() {
                     Err(Consumed::Empty(ParseError::new(input.position, Error::Unexpected(c))))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,7 @@
 //!     let mut integer_list = sep_by(integer, spaces.skip(char(',')));
 //! 
 //!     //Call parse with the input to execute the parser
-//!     let result: Result<(Vec<i32>, &str), ParseError> = integer_list.parse(input);
+//!     let result: Result<(Vec<i32>, &str), ParseError<char>> = integer_list.parse(input);
 //!     match result {
 //!         Ok((value, _remaining_input)) => println!("{:?}", value),
 //!         Err(err) => println!("{}", err)
@@ -99,7 +99,7 @@
 //!```
 
 #[doc(inline)]
-pub use primitives::{Parser, ParseResult, ParseError, from_iter};
+pub use primitives::{Parser, ParseError, from_iter};
 #[doc(inline)]
 pub use char::{
     any_char,
@@ -118,6 +118,8 @@ pub use char::{
     oct_digit,
     string,
     satisfy,
+
+    ParseResult//use char::ParseResult for compatibility
 };
 #[doc(inline)]
 pub use combinator::{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,7 +102,6 @@
 pub use primitives::{Parser, ParseError, from_iter};
 #[doc(inline)]
 pub use char::{
-    any_char,
     char,
     digit,
     space,
@@ -123,6 +122,7 @@ pub use char::{
 };
 #[doc(inline)]
 pub use combinator::{
+    any,
     between,
     chainl1,
     choice,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -288,7 +288,7 @@ r"
         let m = format!("{}", result.unwrap_err());
 let expected =
 r"Parse error at line: 2, column: 1
-Unexpected character ','
+Unexpected token ','
 Expected 'identifier', 'integer', '[' or '('
 ";
         assert_eq!(m, expected);

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -10,19 +10,6 @@ pub struct SourcePosition {
     ///Current column of the input
     pub column: i32
 }
-impl SourcePosition {
-    fn start() -> SourcePosition {
-        SourcePosition { line: 1, column: 1 }
-    }
-
-    fn update(&mut self, c: &char) {
-        self.column += 1;
-        if *c == '\n' {
-            self.column = 1;
-            self.line += 1;
-        }
-    }
-}
 
 ///Struct which represents a position in a byte stream
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd)]
@@ -360,13 +347,6 @@ impl <I: Stream> State<I> {
         }
     }
 }
-impl <I: Stream<Item=char>> State<I> {
-    ///Specialized uncons function for character streams which updates the position
-    ///with no further action needed
-    pub fn uncons_char(self) -> ParseResult<I::Item, I, I::Item> {
-        self.uncons()
-    }
-}
 
 ///A type alias over the specific `Result` type used by parsers to indicate wether they were
 ///successful or not.
@@ -446,10 +426,14 @@ impl <'a, T> Positioner for &'a T
 impl Positioner for char {
     type Position = SourcePosition;
     fn start() -> SourcePosition {
-        SourcePosition::start()
+        SourcePosition { line: 1, column: 1 }
     }
     fn update(&self, position: &mut SourcePosition) {
-        position.update(self);
+        position.column += 1;
+        if *self == '\n' {
+            position.column = 1;
+            position.line += 1;
+        }
     }
 }
 

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -2,7 +2,7 @@ use std::fmt;
 use std::error::Error as StdError;
 use std::any::Any;
 
-///Struct which represents the positions in the source file
+///Struct which represents a position in a source file
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd)]
 pub struct SourcePosition {
     ///Current line of the input
@@ -21,6 +21,19 @@ impl SourcePosition {
             self.column = 1;
             self.line += 1;
         }
+    }
+}
+
+///Struct which represents a position in a byte stream
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd)]
+pub struct BytePosition {
+    ///Current position
+    pub position: usize
+}
+
+impl fmt::Display for BytePosition {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "position: {}", self.position)
     }
 }
 
@@ -437,6 +450,18 @@ impl Positioner for char {
     }
     fn update(&self, position: &mut SourcePosition) {
         position.update(self);
+    }
+}
+
+impl Positioner for u8 {
+    type Position = BytePosition;
+
+    fn start() -> BytePosition {
+        BytePosition { position: 0 }
+    }
+
+    fn update(&self, b: &mut BytePosition) {
+        b.position += 1;
     }
 }
 

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -318,7 +318,7 @@ impl <T: fmt::Display> fmt::Display for Error<T> {
 ///The `State<I>` struct keeps track of the current position in the stream `I`
 #[derive(Clone, PartialEq, Debug)]
 pub struct State<I>
-    where I: Stream, <<I as Stream>::Item as Positioner>::Position: Clone + PartialEq + fmt::Debug {
+    where I: Stream {
     pub position: <<I as Stream>::Item as Positioner>::Position,
     pub input: I
 }
@@ -413,7 +413,7 @@ impl <I: Iterator + Clone> Stream for IteratorStream<I>
 ///When implementing stream for custom token type this must be implemented for that token to allow
 ///the position to be updated
 pub trait Positioner: Clone + PartialEq {
-    type Position: Clone + Ord + fmt::Display + fmt::Debug;
+    type Position: Clone + Ord + fmt::Debug;
     ///Creates a start position
     fn start() -> Self::Position;
     ///Updates the position given that `self` has been taken from the stream

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -24,6 +24,10 @@ impl fmt::Display for BytePosition {
     }
 }
 
+///Enum holding error information
+///As there is implementations of `From` for `T: Positioner`, `String` and `&'static str` the
+///constructor need not be used directly as calling `msg.into()` should turn a message into the
+///correct `Info` variant
 #[derive(Clone, Debug)]
 pub enum Info<T> {
     Token(T),
@@ -387,6 +391,8 @@ impl <'a, T> Stream for &'a [T]
     }
 }
 
+///Wrapper around iterators which allows them to be treated as a stream.
+///Returned by `from_iter`.
 #[derive(Clone, Debug)]
 pub struct IteratorStream<I>(I)
     where I: Iterator + Clone;

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -352,6 +352,8 @@ impl <I: Stream> State<I> {
 ///successful or not.
 ///`O` is the type that is output on success
 ///`I` is the specific stream type used in the parser
+///`T` is the item type of `I`, this parameter will be removed once type declarations are allowed
+///to have trait bounds
 pub type ParseResult<O, I, T> = Result<(O, Consumed<State<I>>), Consumed<ParseError<T>>>;
 
 ///A stream is a sequence of items that can be extracted one by one
@@ -407,9 +409,14 @@ impl <I: Iterator + Clone> Stream for IteratorStream<I>
     }
 }
 
+///`Positioner` represents the operations needed to update a position given an item from the stream
+///When implementing stream for custom token type this must be implemented for that token to allow
+///the position to be updated
 pub trait Positioner: Clone + PartialEq {
     type Position: Clone + Ord + fmt::Display + fmt::Debug;
+    ///Creates a start position
     fn start() -> Self::Position;
+    ///Updates the position given that `self` has been taken from the stream
     fn update(&self, position: &mut Self::Position);
 }
 impl <'a, T> Positioner for &'a T


### PR DESCRIPTION
This is a mostly complete PR of how I think parsing can be made generic in the position. I will leave it as a PR until I can finish documenting it and maybe bring the performance up to the same levels as before.

#### Pros
* any_char, satisfy and char works on any type of stream instead of only char streams (called any, satisfy and token respectively)
* Implementing streams over custom types can use different types for representing and updating positions see: [#L29-L38](https://github.com/Marwes/parser-combinators/blob/8a7d5651c1c5511444b0b353d5b9a4121fbc16f8/src/primitives.rs#L29-L38)   [#L456-L466](https://github.com/Marwes/parser-combinators/blob/8a7d5651c1c5511444b0b353d5b9a4121fbc16f8/src/primitives.rs#L456-L466)

#### Cons
* Being more generic makes it harder for rustc to infer types
* Currently there is a ~5% performance regression on benches/json.rs